### PR TITLE
Remove dev login

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "testwatch-backend": "mix test.watch",
     "startS3": "s3rver -p 4567 --silent -d $HOME/.s3bucket &",
     "stopS3": "kill $(pgrep -f s3rver)",
-    "test-backend": "npm run startS3 && MIX_ENV=test mix do compile, test --trace",
+    "test-backend": "npm run startS3 && MIX_ENV=test mix do compile, test --trace; npm run stopS3",
     "test": "npm run test-backend",
     "test-coverage-backend": "MIX_ENV=test mix do compile --warnings-as-errors, coveralls.json --trace",
     "generate-docs": "apidoc -i web -o docs",

--- a/test/acceptance/sessions_acceptance_test.exs
+++ b/test/acceptance/sessions_acceptance_test.exs
@@ -33,38 +33,4 @@ defmodule Nexpo.SessionsAcceptanceTest do
       assert Map.has_key?(response, "error")
     end
   end
-
-  describe "development" do
-    test "POST /login is successful and returns JWT given valid params", %{conn: conn} do
-      params = Factory.params_for(:user)
-      User.changeset(%User{}, params) |> Repo.insert!()
-
-      params = params |> Map.take([:email])
-      conn = post(conn, "/api/development_login", params)
-
-      assert json_response(conn, 200)
-      response = Poison.decode!(conn.resp_body)["data"]
-
-      assert Map.get(response, "jwt") != nil
-    end
-
-    test "POST /login is unsuccessful and does not return a JWT given invalid params", %{
-      conn: conn
-    } do
-      params = Factory.params_for(:user)
-      User.changeset(%User{}, params) |> Repo.insert!()
-
-      params =
-        params
-        |> Map.take([:email])
-        |> Map.put(:email, params.email <> "invalid")
-
-      conn = post(conn, "/api/development_login", params)
-
-      assert json_response(conn, 404)
-      response = Poison.decode!(conn.resp_body)
-
-      assert Map.has_key?(response, "error")
-    end
-  end
 end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -47,38 +47,6 @@ defmodule Nexpo.SessionController do
     end
   end
 
-  @doc """
-  Endpoint only available in development
-  This allows developers to login as anybody, by only specifying email
-
-  OBS! Only use when run in development mode!
-  """
-  def development_create(conn, %{"email" => email}) do
-    if Mix.env() != :prod do
-      case Repo.get_by(User, email: email |> String.trim() |> String.downcase()) do
-        nil ->
-          conn
-          |> put_status(404)
-          |> render(Nexpo.ErrorView, "404.json")
-
-        user ->
-          permissions = User.get_permissions(user)
-          perms = %{default: permissions}
-          new_conn = Guardian.Plug.api_sign_in(conn, user, %{}, perms: perms, ttl: {72, :hours})
-          jwt = Guardian.Plug.current_token(new_conn)
-          session = %{jwt: jwt, user: user}
-
-          new_conn
-          |> put_resp_header("authorization", "Bearer #{jwt}")
-          |> render("login.json", session: session)
-      end
-    else
-      conn
-      |> put_status(401)
-      |> render(Nexpo.ErrorView, "401.json")
-    end
-  end
-
   # Called when Guardian identifies an unauthenticated jwt
   def unauthenticated(conn, _params) do
     conn

--- a/web/router.ex
+++ b/web/router.ex
@@ -108,10 +108,6 @@ defmodule Nexpo.Router do
 
     post("/login", SessionController, :create)
 
-    if Mix.env() != :prod do
-      post("/development_login", SessionController, :development_create)
-    end
-
     post("/initial_signup", SignupController, :create)
     get("/initial_signup/:key", SignupController, :get_current_signup)
     post("/final_signup/:signup_key", SignupController, :final_create)


### PR DESCRIPTION
Related to https://github.com/careerfairsystems/nexpo-web/pull/2/.

I could not get tests to work, so try to get those working before merging. Now with the added benefit that the s3rver background process is killed when tests are done. 🙌

I get this very uninformative error when running `npm run test`. I have not made any changes to `config/test.exs` since cloning the repo. Those changes described in the readme are already applied.
```
S3rver listening on 127.0.0.1:4567
** (SyntaxError) config/test.exs:41: keyword argument must be followed by space after: http:
    (elixir 1.10.4) lib/code.ex:340: Code.eval_string_with_error_handling/3
    (mix 1.10.4) lib/mix/config.ex:158: anonymous fn/2 in Mix.Config.__import__!/2
    (elixir 1.10.4) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix 1.10.4) lib/mix/config.ex:157: Mix.Config.__import__!/2
    (stdlib 3.13) erl_eval.erl:680: :erl_eval.do_apply/6
```